### PR TITLE
Change file open in read method to use block to ensure file closure.

### DIFF
--- a/lib/configliere/config_file.rb
+++ b/lib/configliere/config_file.rb
@@ -36,10 +36,11 @@ module Configliere
       if filename.is_a?(Symbol) then raise Configliere::DeprecatedError, "Loading from a default config file is no longer provided" ; end
       filename = expand_filename(filename)
       begin
+        str = File.open(filename){ |file| file.read }
         case filetype(filename)
-        when 'json' then read_json(File.open(filename), options)
-        when 'yaml' then read_yaml(File.open(filename), options)
-        else             read_yaml(File.open(filename), options)
+        when 'json' then read_json(str, options)
+        when 'yaml' then read_yaml(str, options)
+        else             read_yaml(str, options)
         end
       rescue Errno::ENOENT
         warn "Loading empty configliere settings file #{filename}"

--- a/spec/configliere/config_file_spec.rb
+++ b/spec/configliere/config_file_spec.rb
@@ -14,7 +14,9 @@ describe Configliere::ConfigFile do
     let(:file_string) { file_params.to_yaml           }
     let(:file_path)   { '/absolute/path.yaml'         }
 
-    before{ File.stub(:open).and_return(file_string) }
+    before{
+      stub_read = double(File, read: file_string)
+      File.stub(:open) { |&stub_file| stub_file.yield stub_read } }
 
     it 'returns the config object for chaining' do
       subject.read(file_path).should == subject


### PR DESCRIPTION
When using the read method, files that were loaded were being held on to by Ruby, as they are never closed. I ran into this issue when trying to delete files that had been previously loaded into a Configliere object.
